### PR TITLE
Drop zope.app.testing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 *.pyc
+.coverage
 .installed.cfg
 .tox/
 bin/

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         test=[
             'z3c.layer.pagelet [test] >= 1.9',
             'zope.app.authentication',
-            'zope.app.testing',
+            'zope.app.wsgi',
             'zope.testbrowser < 5',
             'zope.testing',
         ],

--- a/src/z3c/authviewlet/ftesting.zcml
+++ b/src/z3c/authviewlet/ftesting.zcml
@@ -33,7 +33,7 @@
   <z3c:layout
       for="z3c.authviewlet.tests.LoginLogoutPage"
       layer="z3c.layer.pagelet.IPageletBrowserLayer"
-      template="login-logout-template.pt"
+      template="tests/login-logout-template.pt"
       />
 
   <z3c:pagelet
@@ -54,13 +54,13 @@
   <z3c:layout
       for="z3c.authviewlet.auth.LogoutRedirectPagelet"
       layer="z3c.layer.pagelet.IPageletBrowserLayer"
-      template="login-logout-template.pt"
+      template="tests/login-logout-template.pt"
       />
 
   <z3c:layout
       for="z3c.authviewlet.auth.LogoutSuccessPagelet"
       layer="z3c.layer.pagelet.IPageletBrowserLayer"
-      template="login-logout-template.pt"
+      template="tests/login-logout-template.pt"
       />
 
   <!-- -->

--- a/src/z3c/authviewlet/tests/test_layer.py
+++ b/src/z3c/authviewlet/tests/test_layer.py
@@ -1,41 +1,25 @@
-##############################################################################
-#
-# Copyright (c) 2007-2009 Zope Foundation and Contributors.
-# All Rights Reserved.
-#
-# This software is subject to the provisions of the Zope Public License,
-# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
-# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
-# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
-# FOR A PARTICULAR PURPOSE.
-#
-##############################################################################
-"""
-$Id: __init__.py 97 2007-03-29 22:58:27Z rineichen $
-"""
-
-import re
-import unittest
 from zope.testing import renormalizing
-from zope.app.testing import functional
+import doctest
+import re
+import z3c.authviewlet
+import zope.app.wsgi.testlayer
 
 
-functional.defineLayer('TestLayer', 'ftesting.zcml')
-
-
+TestLayer = zope.app.wsgi.testlayer.BrowserLayer(z3c.authviewlet)
 checker = renormalizing.RENormalizing([
     (re.compile(r'httperror_seek_wrapper:', re.M), 'HTTPError:'),
-    ])
-
-
-def create_suite(*args, **kw):
-    suite = functional.FunctionalDocFileSuite(*args, **kw)
-    suite.layer = TestLayer
-    return suite
+])
+flags = (
+    doctest.ELLIPSIS |
+    doctest.REPORT_UDIFF |
+    doctest.NORMALIZE_WHITESPACE |
+    doctest.REPORT_ONLY_FIRST_FAILURE
+)
 
 
 def test_suite():
-    return unittest.TestSuite((
-        create_suite('../README.txt', checker=checker),
-        ))
+    suite = doctest.DocFileSuite(
+        '../README.txt', checker=checker, optionflags=flags,
+        globs={'layer': TestLayer})
+    suite.layer = TestLayer
+    return suite


### PR DESCRIPTION
Replace the test dependency an zope.app.testing by zope.app.wsgi. 

This one its much less heavy and is needed to support Python 3 in future.