### PR TITLE
Fix dependencies.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 1.1 (unreleased)
 ~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Fix dependencies declared in `setup.py`.
 
 
 1.0 (2017-06-07)

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
     namespace_packages=['z3c'],
     extras_require=dict(
         test=[
-            'z3c.layer.pagelet [test] >= 1.9',
+            'zope.principalregistry',
+            'zope.securitypolicy',
             'zope.pluggableauth',
             'zope.app.wsgi',
             'zope.testbrowser >= 5',
@@ -72,7 +73,7 @@ setup(
     ),
     install_requires=[
         'setuptools',
-        'z3c.layer.pagelet[test] >= 1.9',
+        'z3c.layer.pagelet >= 1.9',
         'zope.authentication',
         'zope.component',
         'zope.i18n',


### PR DESCRIPTION
There is no need for `z3c.layer.pagelet[test]` in the install depenencies.

But `tox` does not seem to be able to use its `test` extras, so declaring the
actually needed dependencies in this extra to get tox running.